### PR TITLE
Updated CEmu to build with VS2015

### DIFF
--- a/CEmu.pro
+++ b/CEmu.pro
@@ -13,7 +13,10 @@ TRANSLATIONS += i18n/fr_FR.ts
 
 CONFIG += c++11
 
-GLOBAL_FLAGS = -W -Wall -Wno-unused-parameter -Werror=shadow -Werror=write-strings -Werror=redundant-decls -Werror=format -Werror=format-security -Werror=implicit-function-declaration -Werror=date-time -Werror=missing-prototypes -Werror=return-type -Werror=pointer-arith -fno-strict-overflow -Winit-self -ffunction-sections -fdata-sections
+# Only add GCC flags if we're not using MSVC
+if (!win32-msvc*) {
+    GLOBAL_FLAGS = -W -Wall -Wno-unused-parameter -Werror=shadow -Werror=write-strings -Werror=redundant-decls -Werror=format -Werror=format-security -Werror=implicit-function-declaration -Werror=date-time -Werror=missing-prototypes -Werror=return-type -Werror=pointer-arith -fno-strict-overflow -Winit-self -ffunction-sections -fdata-sections
+}
 
 if (macx | linux) {
     GLOBAL_FLAGS += -fsanitize=address,bounds -fsanitize-undefined-trap-on-error -fstack-protector-all -Wstack-protector --param=ssp-buffer-size=1 -fPIC
@@ -26,8 +29,19 @@ if (linux) {
 }
 
 QMAKE_CFLAGS += $$GLOBAL_FLAGS
-QMAKE_CXXFLAGS += $$GLOBAL_FLAGS -fno-exceptions
-QMAKE_LFLAGS += -flto -fPIE $$GLOBAL_FLAGS $$MORE_LFLAGS
+
+if (!win32-msvc*) {
+    # GCC specific flags
+    QMAKE_CXXFLAGS += $$GLOBAL_FLAGS -fno-exceptions
+    QMAKE_LFLAGS += -flto -fPIE $$GLOBAL_FLAGS $$MORE_LFLAGS
+} else {
+    # MSVC specific flags
+    # TODO: add equivalent -Werror flags
+    # For -Werror=shadow: /weC4456 /weC4457 /weC4458 /weC4459
+    #     Source: https://connect.microsoft.com/VisualStudio/feedback/details/1355600/
+    QMAKE_CXXFLAGS += /Wall $$GLOBAL_FLAGS
+    QMAKE_LFLAGS += $$GLOBAL_FLAGS $$MORE_LFLAGS
+}
 
 ios {
     DEFINES += IS_IOS_BUILD
@@ -35,7 +49,6 @@ ios {
 }
 
 macx: ICON = resources/icons/icon.icns
-
 
 SOURCES +=  utils.cpp \
     main.cpp\

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ Nightly win32 binaries available here (hosted by pimathbrainiac): http://pimathb
 After downloading the source (you can clone the repo or just get the zip):
 
 1. Get the [latest Qt5 SDK](https://www.qt.io/download-open-source/#section-3) for your OS.
+  * On Windows, if you are building with Visual Studio, you must use
+    Visual Studio 2015 or newer. You also must download a Qt build that
+	is compatible with Visual Studio 2015 or newer.
+	* If you don't have Visual Studio 2015 installed, we recommen
+	  installing [Visual Studio 2015 Community](https://go.microsoft.com/fwlink/?LinkId=691978&clcid=0x409).
+	* Qt v5.6 is the only version of Qt (at the moment) that supports
+	  VS2015. You can download the beta version of Qt v5.6
+	  [here](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/).
+	  * Direct download links for Qt v5.6:
+	    [MSVC 2015 x86](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/qt-opensource-windows-x86-msvc2015-5.6.0-beta.exe)
+	    or [MSVC 2015 x64](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/qt-opensource-windows-x86-msvc2015_64-5.6.0-beta.exe)
+    * Note that the latest Qt v5.6 beta has a bug where the version of
+	  MSVC is incorrect. (It is displayed as 2013 or older.) This is
+	  simply a display bug. To ensure that you are using MSVC 2015,
+	  check the actual compiler version and ensure that it is 14.0
+	  or newer.
+	  
 2. Now you have two options:
   * Open the .pro file with Qt Creator, set it up (default project settings should be fine), and hit Build
   * In a shell, cd to the project folder and type `qmake -r CEmu.pro; make`

--- a/README.md
+++ b/README.md
@@ -20,21 +20,27 @@ After downloading the source (you can clone the repo or just get the zip):
 1. Get the [latest Qt5 SDK](https://www.qt.io/download-open-source/#section-3) for your OS.
   * On Windows, if you are building with Visual Studio, you must use
     Visual Studio 2015 or newer. You also must download a Qt build that
-	is compatible with Visual Studio 2015 or newer.
-	* If you don't have Visual Studio 2015 installed, we recommen
-	  installing [Visual Studio 2015 Community](https://go.microsoft.com/fwlink/?LinkId=691978&clcid=0x409).
-	* Qt v5.6 is the only version of Qt (at the moment) that supports
-	  VS2015. You can download the beta version of Qt v5.6
-	  [here](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/).
-	  * Direct download links for Qt v5.6:
-	    [MSVC 2015 x86](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/qt-opensource-windows-x86-msvc2015-5.6.0-beta.exe)
-	    or [MSVC 2015 x64](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/qt-opensource-windows-x86-msvc2015_64-5.6.0-beta.exe)
+    is compatible with Visual Studio 2015 or newer.
+    
+    * If you don't have Visual Studio 2015 installed, we recommend
+      installing [Visual Studio 2015 Community](https://go.microsoft.com/fwlink/?LinkId=691978&clcid=0x409).
+    
+    * Qt v5.6 is the only version of Qt (at the moment) that supports
+      VS2015.
+      
+      * You can download the beta version of Qt v5.6
+        [here](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/).
+      
+      * Direct download links for Qt v5.6 (VS2015):
+        [MSVC 2015 x86](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/qt-opensource-windows-x86-msvc2015-5.6.0-beta.exe)
+        and [MSVC 2015 x64](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/qt-opensource-windows-x86-msvc2015_64-5.6.0-beta.exe)
+    
     * Note that the latest Qt v5.6 beta has a bug where the version of
-	  MSVC is incorrect. (It is displayed as 2013 or older.) This is
-	  simply a display bug. To ensure that you are using MSVC 2015,
-	  check the actual compiler version and ensure that it is 14.0
-	  or newer.
-	  
+      MSVC is incorrect. (It is displayed as 2013 or older.) This is
+      simply a display bug. To ensure that you are using MSVC 2015,
+      check the actual compiler version and ensure that it is 14.0
+      or newer.
+    
 2. Now you have two options:
   * Open the .pro file with Qt Creator, set it up (default project settings should be fine), and hit Build
   * In a shell, cd to the project folder and type `qmake -r CEmu.pro; make`

--- a/README.md
+++ b/README.md
@@ -21,20 +21,15 @@ After downloading the source (you can clone the repo or just get the zip):
   * On Windows, if you are building with Visual Studio, you must use
     Visual Studio 2015 or newer. You also must download a Qt build that
     is compatible with Visual Studio 2015 or newer.
-    
     * If you don't have Visual Studio 2015 installed, we recommend
       installing [Visual Studio 2015 Community](https://go.microsoft.com/fwlink/?LinkId=691978&clcid=0x409).
-    
     * Qt v5.6 is the only version of Qt (at the moment) that supports
       VS2015.
-      
       * You can download the beta version of Qt v5.6
         [here](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/).
-      
       * Direct download links for Qt v5.6 (VS2015):
         [MSVC 2015 x86](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/qt-opensource-windows-x86-msvc2015-5.6.0-beta.exe)
         and [MSVC 2015 x64](http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/qt-opensource-windows-x86-msvc2015_64-5.6.0-beta.exe)
-    
     * Note that the latest Qt v5.6 beta has a bug where the version of
       MSVC is incorrect. (It is displayed as 2013 or older.) This is
       simply a display bug. To ensure that you are using MSVC 2015,


### PR DESCRIPTION
I've updated CEmu to now build with VS2015. No source code has been modified - only the project file `CEmu.pro` has been updated. I've also updated the README for information on building with VS2015.

Haven't gotten a chance (or a good build environment!) to test against building with Linux/Mac, so please check to make sure nothing broke!

Other things to consider:
  * Do we want to stick to VS2015? (Related discussion in #1)
  * Do we want to add AppVeyor support? Might be messy, but not impossible.
